### PR TITLE
Update blog page to get children page

### DIFF
--- a/templates/blog.html.twig
+++ b/templates/blog.html.twig
@@ -1,6 +1,6 @@
 {% embed 'partials/base.html.twig' %}
 
-  {% set collection = page.collection() %}
+  {% set collection = page.children() %}
   {% set base_url = page.url %}
   {% set feed_url = base_url %}
 


### PR DESCRIPTION
Using the develop version of grav the `collection()` return empty list, I need to use `children()` method to get the list of children pages.