### PR TITLE
Fixed date format

### DIFF
--- a/templates/partials/blog_item.html.twig
+++ b/templates/partials/blog_item.html.twig
@@ -67,7 +67,7 @@
 
     <footer class="entry-footer">
         <span class="posted-on">
-            <time class="entry-date published updated" datetime="{{ page.date|date(config.system.pages.dateformat.short) }}">{{ 'MONTHS_OF_THE_YEAR'|ta(page.date|date('n') - 1) }} {{ page.date|date(config.system.pages.dateformat.default) }}</time> 
+            <time class="entry-date published updated" datetime="{{ page.date|date('Y-m-d') }}">{{ 'MONTHS_OF_THE_YEAR'|ta(page.date|date('n') - 1) }} {{ page.date|date('d, Y') }}</time> 
         </span>
         {% if page.header.author %}
             <span class="byline">


### PR DESCRIPTION
This kind of hacks shoulds not be propagated on the config level (pages.dateformat.default), and stay with the hack.
Also, this break usage of admin plugin which use "pages.dateformat.default" with the datepicker.