### PR TITLE
fix simplesearch integration 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-
+.idea
 .DS_Store

--- a/templates/partials/base.html.twig
+++ b/templates/partials/base.html.twig
@@ -61,6 +61,7 @@
 </div>
 
 {% block javascripts_bottom %}
+    {{ assets.js('bottom') }}
     <script type='text/javascript'>
     /* <![CDATA[ */
     var screenReaderText = {"expand":"<span class=\"screen-reader-text\">expand child menu<\/span>","collapse":"<span class=\"screen-reader-text\">collapse child menu<\/span>"};

--- a/templates/partials/blog_item.html.twig
+++ b/templates/partials/blog_item.html.twig
@@ -85,6 +85,19 @@
     </footer>
 </article>
 
+{% if not truncate %}
+    {% if config.plugins.comments.enabled %}
+        <div id="comments" class="comments-area">
+            {% include 'partials/comments.html.twig' %}
+        </div>
+    {% endif %}
+    {% if config.plugins.jscomments.enabled %}
+        <div id="comments" class="comments-area">
+            {{ jscomments()|raw }}
+        </div>
+    {% endif %}
+{% endif %}
+
 {% if show_prev_next %}
 {% if page.nextSibling.media.images %}
 <style type="text/css">

--- a/templates/partials/simplesearch_item.html.twig
+++ b/templates/partials/simplesearch_item.html.twig
@@ -1,0 +1,1 @@
+{% include 'partials/blog_item.html.twig' with {'truncate':true} %}


### PR DESCRIPTION
searches have no search result because the `simplesearch.js` was missing and the form was executed as `/?searchfield=foo` instead of `/search/query:foo`. To fix this I added the assets of the js-bottom-group (like in the antimatter theme)

To improve the search result I included `blog_item.html.twig` as `simplesearch_item.html.twig`.

![search_result](https://user-images.githubusercontent.com/1407477/29506863-fea13888-864d-11e7-99db-6273c4335fd4.png)

I'll be grateful if you could accept this PR.